### PR TITLE
Fix typo in end of campaign final score screen

### DIFF
--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -2638,7 +2638,7 @@ new_game:
 						if (twoPlayerMode)
 						{
 							for (uint i = 0; i < 2; ++i)
-								snprintf(levelWarningText[i], sizeof(*levelWarningText), "%s %lu", miscText[40], player[i].cash);
+								snprintf(levelWarningText[i], sizeof(*levelWarningText), "%s %lu", miscText[40+i], player[i].cash);
 							strcpy(levelWarningText[2], "");
 							levelWarningLines = 3;
 						}


### PR DESCRIPTION
As per issue https://github.com/opentyrian/opentyrian/issues/62
Now correctly reads "Player 1 Score: " and "Player 2 Score" (when in two player mode.)